### PR TITLE
Add comprehensive POSIX wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # anonymos-posix
+
+This repository provides wrappers for POSIX system calls that can be used with
+[anonymOS's internetcomputer](https://github.com/Jonathan-R-Anderson/internetcomputer)
+microkernel.  The wrappers are implemented in D and compiled with the
+cross-compiled `ldc2` used by the OS build.
+
+Most wrappers simply forward to the host C library.  The goal is to expose a
+complete POSIX surface usable from `-betterC` D code.  See `src/posix.d` for the
+current list of supported calls.
+
+## Building
+
+The library can be built either with the host `ldc2` or with the cross
+compiler from the internetcomputer repository.  An example using the cross
+compiler:
+
+```bash
+# assuming ../internetcomputer/build/bin/ldc2 exists
+../internetcomputer/build/bin/ldc2 \
+    -betterC -I=src examples/test.d src/posix.d -of=test
+./test | head -n 2
+```
+
+This should print the first lines of `README.md` demonstrating that the
+wrappers work under the cross compiler as well.

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,9 @@
+{
+    "name": "anonymos-posix",
+    "description": "POSIX syscall wrappers for internetcomputer",
+    "authors": ["Jonathan Anderson"],
+    "license": "MIT",
+    "targetType": "library",
+    "sourcePaths": ["src"],
+    "dflags": ["-betterC", "-mtriple=x86_64-unknown-elf"]
+}

--- a/examples/test.d
+++ b/examples/test.d
@@ -1,0 +1,23 @@
+module app;
+
+import posix;
+import core.stdc.stdio : printf;
+
+extern(C) void main()
+{
+    printf("pid=%d\n", posix_getpid());
+    int fd = posix_open("README.md", O_RDONLY, 0);
+    if(fd < 0)
+    {
+        printf("open failed\n");
+        posix_exit(1);
+    }
+    char[64] buf;
+    auto n = posix_read(fd, buf.ptr, buf.length);
+    if(n > 0)
+    {
+        printf("%.*s", cast(int)n, buf.ptr);
+    }
+    posix_close(fd);
+    posix_exit(0);
+}

--- a/src/posix.d
+++ b/src/posix.d
@@ -1,0 +1,202 @@
+module posix;
+
+pragma(LDC_no_moduleinfo);
+
+extern(C) @nogc nothrow:
+
+import core.sys.posix.unistd : read, write, close, lseek = lseek64, fork, execve, pipe, chdir, getcwd, dup, dup2, unlink, rmdir, getpid, getppid, getuid, geteuid, getgid, getegid, chown, fchown, sleep, usleep;
+import core.sys.posix.sys.types : useconds_t;
+import core.sys.posix.stdio : rename;
+import core.sys.posix.signal : kill;
+import core.sys.posix.sys.wait : waitpid;
+public import core.sys.posix.fcntl : open, O_RDONLY, O_WRONLY, O_RDWR, O_CREAT,
+    O_TRUNC, O_APPEND, fcntl, creat;
+import core.sys.posix.sys.stat : stat, fstat, lstat, stat_t, mode_t, off_t, chmod, fchmod, mkdir, umask;
+import core.stdc.stdlib : exit;
+
+// Basic wrappers around common POSIX syscalls. The functions simply
+// forward to the underlying C library so they can be used from D code
+// compiled with the cross-compiler.
+
+int posix_open(const(char)* path, int flags, mode_t mode)
+{
+    return open(path, flags, mode);
+}
+
+long posix_read(int fd, void* buf, ulong count)
+{
+    return read(fd, buf, count);
+}
+
+long posix_write(int fd, const(void)* buf, ulong count)
+{
+    return write(fd, buf, count);
+}
+
+int posix_close(int fd)
+{
+    return close(fd);
+}
+
+long posix_lseek(int fd, off_t offset, int whence)
+{
+    return lseek(fd, offset, whence);
+}
+
+int posix_pipe(int* fds)
+{
+    int[2] tmp;
+    int rc = pipe(tmp);
+    if(rc == 0)
+    {
+        fds[0] = tmp[0];
+        fds[1] = tmp[1];
+    }
+    return rc;
+}
+
+int posix_dup(int fd)
+{
+    return dup(fd);
+}
+
+int posix_dup2(int oldfd, int newfd)
+{
+    return dup2(oldfd, newfd);
+}
+
+int posix_chdir(const(char)* path)
+{
+    return chdir(path);
+}
+
+char* posix_getcwd(char* buf, size_t size)
+{
+    return getcwd(buf, size);
+}
+
+int posix_unlink(const(char)* path)
+{
+    return unlink(path);
+}
+
+int posix_mkdir(const(char)* path, mode_t mode)
+{
+    return mkdir(path, mode);
+}
+
+int posix_rmdir(const(char)* path)
+{
+    return rmdir(path);
+}
+
+int posix_rename(const(char)* old, const(char)* newp)
+{
+    return rename(old, newp);
+}
+
+int posix_fork()
+{
+    return fork();
+}
+
+int posix_execve(const(char)* path, char** argv, char** envp)
+{
+    return execve(path, argv, envp);
+}
+
+int posix_waitpid(int pid, int* status, int options)
+{
+    return waitpid(pid, status, options);
+}
+
+void posix_exit(int status)
+{
+    exit(status);
+}
+
+int posix_kill(int pid, int sig)
+{
+    return kill(pid, sig);
+}
+
+int posix_stat(const(char)* path, stat_t* buf)
+{
+    return stat(path, buf);
+}
+
+int posix_fstat(int fd, stat_t* buf)
+{
+    return fstat(fd, buf);
+}
+
+int posix_lstat(const(char)* path, stat_t* buf)
+{
+    return lstat(path, buf);
+}
+
+int posix_chmod(const(char)* path, mode_t mode)
+{
+    return chmod(path, mode);
+}
+
+int posix_fchmod(int fd, mode_t mode)
+{
+    return fchmod(fd, mode);
+}
+
+int posix_chown(const(char)* path, int uid, int gid)
+{
+    return chown(path, uid, gid);
+}
+
+int posix_fchown(int fd, int uid, int gid)
+{
+    return fchown(fd, uid, gid);
+}
+
+uint posix_umask(uint mask)
+{
+    return umask(mask);
+}
+
+int posix_getpid()
+{
+    return getpid();
+}
+
+int posix_getppid()
+{
+    return getppid();
+}
+
+int posix_getuid()
+{
+    return getuid();
+}
+
+int posix_geteuid()
+{
+    return geteuid();
+}
+
+int posix_getgid()
+{
+    return getgid();
+}
+
+int posix_getegid()
+{
+    return getegid();
+}
+
+uint posix_sleep(uint seconds)
+{
+    return sleep(seconds);
+}
+
+int posix_usleep(useconds_t usec)
+{
+    return usleep(usec);
+}
+


### PR DESCRIPTION
## Summary
- document building with internetcomputer cross compiler
- compile library with cross triple in `dub.json`
- extend example to call `posix_getpid`
- implement many additional POSIX system calls

## Testing
- `ldc2 -betterC -I=src examples/test.d src/posix.d -of=test && ./test | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_68622375f17c83279be26bea8d37b5ba